### PR TITLE
add cjson module

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@
 - [v-regex](https://github.com/spytheman/v-regex) - A simple regex library for V.
 - [chalk](https://github.com/etienne-napoleone/chalk) - Colorize strings in the terminal.
 - [crayon](https://github.com/thecodrr/crayon) - Paint your terminal output like Picasso. 🖍️🎨
+- [cjson](https://github.com/lydiandy/cjson) - wrap cJSON for vlang
 
 ### Graphics
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@
 - [v-regex](https://github.com/spytheman/v-regex) - A simple regex library for V.
 - [chalk](https://github.com/etienne-napoleone/chalk) - Colorize strings in the terminal.
 - [crayon](https://github.com/thecodrr/crayon) - Paint your terminal output like Picasso. 🖍️🎨
-- [cjson](https://github.com/lydiandy/cjson) - wrap cJSON for vlang
+- [cjson](https://github.com/lydiandy/cjson) - Wrap cJSON for vlang.
 
 ### Graphics
 


### PR DESCRIPTION
V already has the standard json module base on cJSON,but only public json.encode() and json.decode(). 
sometimes we may need to use cjson directly.