### PR TITLE
readme: V Playground link change

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@
 
 ### Online IDEs with V
 
-- [V Playground](https://vlang.io/play)
+- [V Playground](https://v-wasm.now.sh/)
 - [DevBits V Playground](https://devbits.app/play?lang=v&code64=Zm4gbWFpbigpIHsKCWFyZWFzIDo9IFsnZ2FtZScsICd3ZWInLCAndG9vbHMnLCAnc2NpZW5jZScsICdzeXN0ZW1zJywgJ2VtYmVkZGVkJywgJ2RyaXZlcnMnLCAnR1VJJywgJ21vYmlsZSddIAoJZm9yIGFyZWEgaW4gYXJlYXMgewoJCXByaW50bG4oJ0hlbGxvLCAkYXJlYSBkZXZlbG9wZXJzIScpCgl9Cn0K)
 
 ### Articles


### PR DESCRIPTION
I have changed the old playground link for the new one.

``(https://vlang.io/play)`` by ``(https://v-wasm.now.sh/)``