### PR TITLE
add vcredits

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@
 - [vast](https://github.com/lydiandy/vast) - A simple tool for vlang, generate v source file to AST json file.
 - [symlinker](https://github.com/serkonda7/symlinker) - A small Linux tool to manage symlinks.
 - [runner](https://github.com/Naheel-Azawy/runner) - A tool that automates running/compiling code written in various programming languages.
-- [vcredits](https://github.com/zakuro9715/vcredits) - A tool that creates CERDITS from LICENSE files of dependencies.
+- [vcredits](https://github.com/zakuro9715/vcredits) - A tool that creates CDEITS from LICENSE files of dependencies.
 - [vspect](https://github.com/zakuro9715/vspect) - A tool to inspect vlang source file.
 
 ### Project management

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 - [vast](https://github.com/lydiandy/vast) - A simple tool for vlang, generate v source file to AST json file.
 - [symlinker](https://github.com/serkonda7/symlinker) - A small Linux tool to manage symlinks.
 - [runner](https://github.com/Naheel-Azawy/runner) - A tool that automates running/compiling code written in various programming languages.
+- [vcredits](https://github.com/zakuro9715/vcredits) - A tool that creates CERDITS from LICENSE files of dependencies.
 - [vspect](https://github.com/zakuro9715/vspect) - A tool to inspect vlang source file.
 
 ### Project management

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@
 - [vast](https://github.com/lydiandy/vast) - A simple tool for vlang, generate v source file to AST json file.
 - [symlinker](https://github.com/serkonda7/symlinker) - A small Linux tool to manage symlinks.
 - [runner](https://github.com/Naheel-Azawy/runner) - A tool that automates running/compiling code written in various programming languages.
-- [vcredits](https://github.com/zakuro9715/vcredits) - A tool that creates CDEITS from LICENSE files of dependencies.
+- [vcredits](https://github.com/zakuro9715/vcredits) - A tool that creates CREDITS from LICENSE files of dependencies.
 - [vspect](https://github.com/zakuro9715/vspect) - A tool to inspect vlang source file.
 
 ### Project management


### PR DESCRIPTION
vcredits is a tool that creates CERDITS from LICENSE files of dependencies.

vcredits inspired by [gocredits](https://github.com/Songmu/gocredits)

> When distributing built executable in Go, we need to include LICENSE of the dependent libraries into the package, so gocredits bundle them together as a CREDITS file.

This is same for V.