### PR TITLE
fix: change my setup-v-action to the official V action

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@
 
 ### GitHub actions
 
-- [setup-v](https://github.com/marketplace/actions/setup-vlang) - GitHub action to install and use V in your any of your workflow.
+- [setup-v](https://github.com/marketplace/actions/setup-vlang) - GitHub action to install and use V in your workflow.
 - [action-create-v-docs](https://github.com/marketplace/actions/create-documentation-for-v-modules) - GitHub action to create documentation for V modules.
 
 ### Videos

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@
 
 ### GitHub actions
 
-- [setup-v-action](https://github.com/marketplace/actions/setup-v-environment) - GitHub action automation to use V in your workflow.
+- [setup-v](https://github.com/marketplace/actions/setup-vlang) - GitHub action to install and use V in your any of your workflow.
 - [action-create-v-docs](https://github.com/marketplace/actions/create-documentation-for-v-modules) - GitHub action to create documentation for V modules.
 
 ### Videos


### PR DESCRIPTION
I made my action deprecated some time ago because of V orgs now own it's action to setup V.

I've redirect people to V action and I think it's better to set the link here too.