### PR TITLE
README.md: fix anchor link to libraries/files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 	- [Database clients](#database-clients)
 	- [Discord](#discord)
 	- [Eventing](#eventing)
-	- [Files](#files)
+	- [Files](#Files)
 	- [Game development](#game-development)
 	- [Graphics](#graphics-1)
 	- [IRC](#irc)

--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@
 	- [Database clients](#database-clients)
 	- [Discord](#discord)
 	- [Eventing](#eventing)
-	<!--lint disable awesome-list-item-->
-	- [Files](#Files)
-	<!--lint enable awesome-list-item-->
+	- [File handling](#file-handling)
 	- [Game development](#game-development)
 	- [Graphics](#graphics-1)
 	- [IRC](#irc)
@@ -181,7 +179,7 @@
 
 - [eventbus](https://github.com/vlang/v/tree/master/vlib/eventbus) - A simple event bus system for V.
 
-### Files
+### File handling
 
 - [v-mime](https://github.com/nedpals/v-mime) - MIME detection library for V.
 - [vmon](https://github.com/Larpon/vmon) - Asynchronously watch for file changes in a directory. The module is essentially a V wrapper for `septag/dmon`. It works for Windows, macOS and Linux.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@
 	- [Database clients](#database-clients)
 	- [Discord](#discord)
 	- [Eventing](#eventing)
+	<!--lint disable awesome-list-item-->
 	- [Files](#Files)
+	<!--lint enable awesome-list-item-->
 	- [Game development](#game-development)
 	- [Graphics](#graphics-1)
 	- [IRC](#irc)


### PR DESCRIPTION
<details>
<summary><em>Old PR description</em></summary>

Found by accident while checking for some awesome v libs. Lowercase `#files` links to the actual files of the repository.

edit: using title-case apparently breaks linting. Trying to append a number to the lowercase version - like it would usually work for duplicate headers - doesn't seem to work. Renaming the section to something like `File handling` or `File management` might be an option to have a working link and keep the linter happy.

edit2: Well, re-checked and thought that's what linter exceptions are made for. Apparently this lets me run into more errors. If you think `Libraries > File management` || `Libraries > File handling` is appropriate lets go with that :+1: 
</details>

Fixes an issue where clicking "Files" moves the focus to the top of the repository instead of going towards the associated heading.

I'd just suggest `File handling` to get this resolved. The term encompasses both file system and file management, and the items fit in there. Other solutions initially thought of like messing around with exceptions might be not a proper solution for such a problem in the end I think.