### PR TITLE
Add lexical_uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@
 - [v-regex](https://github.com/spytheman/v-regex) - A simple regex library for V.
 - [vxml](https://github.com/walkingdevel/vxml) - Pure V library for parsing XML to a DOM.
 - [whisker](https://github.com/hungrybluedev/whisker) - Fast, robust template engine for V inspired by mustache.
+- [lexical_uuid](https://github.com/Coachonko/lexical_uuid) - Lexicographically-sortable universally unique identifiers.
 
 ### User Interface toolkits
 


### PR DESCRIPTION
I built lexical_uuid today as an exercise to understand the UUIDv7 implementation Bradley Peabody suggested in draft 1 and 2.
It will never be a standard but I think it can still be used.