### PR TITLE
readme: sokol_gp

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@
 
 - [V Earcut](https://github.com/Larpon/earcut) - fast (real-time) polygon triangulation library based on [mapbox/Earcut](https://github.com/mapbox/earcut) to handle holes, twisted polygons, degeneracies and self-intersections.
 - [V_sokol_gp](https://github.com/mohamedLT/V_sokol_gp) - A V wrapper for the sokol_gp library for easy and fast 2d graphics.
+- [sokol_gp](https://github.com/sudokit/v_sokol_gp) - A up-to-date V wrapper for sokol_gp.
 - [viup](https://github.com/kjlaw89/viup) - V wrapper for the C-based cross-platform UI library, IUP.
 - [vsdl](https://github.com/kjlaw89/vsdl) - V wrapper for the C-based SDL library.
 - [vsdl2](https://github.com/nsauzede/vsdl2) - A libSDL2 wrapper.


### PR DESCRIPTION
a more up-to-date wrapper for sokol_gp library (felt wrong just to replace the other)