### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@
 - [strfmt](https://github.com/BenStigsen/strfmt) - Tiny and fast string formatting library ideal for templating.
 - [text-processing](https://github.com/ArtemkaKun/text-processing) - V text processing library, that contains common tools to manipulate text data.
 - [v-regex](https://github.com/spytheman/v-regex) - A simple regex library for V.
-- [vxml](https://github.com/walkingdevel/vxml) - Pure V library for parsing XML to a DOM.
+- [vxml](https://github.com/i582/vxml) - Pure V library for parsing XML to a DOM.
 - [whisker](https://github.com/hungrybluedev/whisker) - Fast, robust template engine for V inspired by mustache.
 - [lexical_uuid](https://github.com/einar-hjortdal/lexical_uuid) - Lexicographically-sortable universally unique identifiers.
 


### PR DESCRIPTION
github.com/walkingdevel/vxml no longer available (disappeared around August 2024. Archive.org did not archive all files from the project, therefore I replaced it with another fork which is still available.