### PR TITLE
Add limine-v-template & v-limine

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,9 @@
 
 ### Operating Systems & OS Development Examples
 
+- [limine-v-template](https://github.com/plos-clan/limine-v-template) - A simple template for building a Limine-compliant kernel in V.
 - [Simple Linux kernel module example](https://github.com/spytheman/simple_kernel_module_in_v) - Demonstration & test of writing a very simple Linux kernel module, using V.
+- [v-limine](https://github.com/wenxuanjun/v-limine) - A V library for handling Limine boot protocol structures.
 
 ### Patterns
 


### PR DESCRIPTION
`v-limine` is a V library for handling Limine boot protocol structures. Compared to the `limine` module in `vinix` and `unikernel`, it has been rewritten and supports the latest `Base revision 3`. Currently its non-x86_64 targets support is not perfect, but it is actively maintained and more useful features will be added.

`limine-v-template` is a simple template for building a Limine-compliant kernel in V with `limine` module like [other limine templates](https://github.com/limine-bootloader/limine-c-template-x86-64). It currently only generates ISO image for x86_64 and the build scripts for other targets are in preparation.