### PR TITLE
Add boj-server to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ SDL2 and SDL3 based applications importing `vlang/sdl`.
 
 ### Utilities
 
+- [boj-server](https://github.com/hyperpolymath/boj-server) - Unified developer tool server using V for the network adapter layer. Exposes REST (port 7700), gRPC (7701), and GraphQL (7702) from a single V codebase. 18 capability cartridges loaded via Zig FFI with Idris2-verified interfaces.
 - [emoji-mart-desktop](https://github.com/ttytm/emoji-mart-desktop) - An emoji picker created with V, webview and SvelteKit.
 - [v-nodejs-addon](https://github.com/fanlia/v-nodejs-addon) - An demo of how to create a Node.js addon with V.
 


### PR DESCRIPTION
## Add boj-server

Adds [boj-server](https://github.com/hyperpolymath/boj-server) to the Utilities section.

**V-lang usage:** BoJ Server uses V for the network adapter layer — exposing REST (port 7700), gRPC-compat (7701), and GraphQL (7702) endpoints from a single V codebase. The V adapter layer wraps 18 capability cartridges loaded via Zig FFI with Idris2-verified interfaces.

- **License:** PMPL-1.0-or-later
- **307 tests passing**
- Community project, open to contributors