### PR TITLE
Add tree-sitter-v: tree-sitter grammar for V (maintained fork)

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ SDL2 and SDL3 based applications importing `vlang/sdl`.
 
 ### Text processing
 
+- [tree-sitter-v](https://github.com/undivisible/tree-sitter-v) - Tree-sitter grammar for V language. Maintained fork with modern API, crates.io package, 244 node types.
+
 - [ascii_robot](https://github.com/Delta456/ascii_robot) - ASCII Robot generator written in V.
 - [chalk](https://github.com/etienne-napoleone/chalk) - Colorize strings in the terminal.
 - [cjson](https://github.com/lydiandy/cjson) - Wrap cJSON for vlang.

--- a/README.md
+++ b/README.md
@@ -339,7 +339,6 @@ SDL2 and SDL3 based applications importing `vlang/sdl`.
 
 ### Text processing
 
-- [tree-sitter-v](https://github.com/undivisible/tree-sitter-v) - Tree-sitter grammar for V language. Maintained fork with modern API, crates.io package, 244 node types.
 
 - [ascii_robot](https://github.com/Delta456/ascii_robot) - ASCII Robot generator written in V.
 - [chalk](https://github.com/etienne-napoleone/chalk) - Colorize strings in the terminal.
@@ -423,6 +422,8 @@ SDL2 and SDL3 based applications importing `vlang/sdl`.
 - [V Community](https://github.com/v-community)
 
 ### Editor plugins
+
+- [tree-sitter-v](https://github.com/undivisible/tree-sitter-v) - Tree-sitter grammar for V language. Maintained fork with modern API, crates.io package, 244 node types.
 
 #### Atom
 


### PR DESCRIPTION
Adds [tree-sitter-v](https://github.com/undivisible/tree-sitter-v) under Editor plugins — a tree-sitter grammar for V language with 244 node types, modern API, and crates.io publishing.\n\nForked from [nedpals/tree-sitter-v](https://github.com/nedpals/tree-sitter-v) (unmaintained since 2023), updated to tree-sitter 0.26+.