### PR TITLE
Add setup-v GitHub repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ SDL2 and SDL3 based applications importing `vlang/sdl`.
 ### GitHub Actions
 
 - [action-create-v-docs](https://github.com/marketplace/actions/create-documentation-for-v-modules) - GitHub action to create documentation for V modules.
-- [setup-v](https://github.com/marketplace/actions/setup-vlang) - GitHub action to install and use V in your workflow.
+- [setup-v](https://github.com/vlang/setup-v) - GitHub Action to install and use V in your workflow. Available on the [marketplace](https://github.com/marketplace/actions/setup-vlang).
 
 ### GitHub templates
 


### PR DESCRIPTION
## What

Updates the setup-v entry in the GitHub actions section to include the GitHub repository link (`https://github.com/vlang/setup-v`) as the primary URL, keeping the marketplace listing reference in the description.

## Why

The repository link provides more context (source code, open issues, contributing guidelines) than the marketplace listing alone.

## References
- https://github.com/vlang/setup-v
- https://github.com/marketplace/actions/setup-vlang